### PR TITLE
Updates to use oauth-proxy rather than kong-bff-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 license.json
 token-handler-api
-kong-bff-plugin
+oauth-proxy-plugin
 kong-phantom-token-plugin
 financial/certs/example*
 .DS_Store

--- a/financial/build.sh
+++ b/financial/build.sh
@@ -62,13 +62,6 @@ if [ $? -ne 0 ]; then
 fi
 
 #
-# Temporary code OAuth proxy plugin changes are merged
-#
-cd oauth-proxy-plugin
-git checkout feature/nginx-lua-oauth-proxy-plugin
-cd ..
-
-#
 # Also download the phantom token plugin for the reverse proxy
 #
 rm -rf kong-phantom-token-plugin

--- a/financial/build.sh
+++ b/financial/build.sh
@@ -54,12 +54,19 @@ fi
 # Get the 'OAuth Proxy', which is a simple reverse proxy plugin
 #
 cd ..
-rm -rf kong-bff-plugin
-git clone https://github.com/curityio/kong-bff-plugin
+rm -rf oauth-proxy-plugin
+git clone https://github.com/curityio/kong-bff-plugin oauth-proxy-plugin
 if [ $? -ne 0 ]; then
-  echo "Problem encountered downloading the BFF plugin"
+  echo "Problem encountered downloading the OAuth proxy plugin"
   exit 1
 fi
+
+#
+# Temporary code OAuth proxy plugin changes are merged
+#
+cd oauth-proxy-plugin
+git checkout feature/nginx-lua-oauth-proxy-plugin
+cd ..
 
 #
 # Also download the phantom token plugin for the reverse proxy

--- a/financial/docker-compose.yml
+++ b/financial/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - 3000:3000
     volumes:
       - ./reverse-proxy/kong.yml:/usr/local/kong/declarative/kong.yml
-      - ./kong-bff-plugin/plugin:/usr/local/share/lua/5.1/kong/plugins/bff-token
+      - ./oauth-proxy-plugin/plugin:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy
       - ./kong-phantom-token-plugin/plugin:/usr/local/share/lua/5.1/kong/plugins/phantom-token
       - ./certs/example.ca.pem:/usr/local/share/certs/example.ca.pem
       - ./certs/example.server.key:/usr/local/share/certs/example.server.key
@@ -95,7 +95,7 @@ services:
       KONG_SSL_CERT_KEY: './usr/local/share/certs/example.server.key'
       KONG_LUA_SSL_TRUSTED_CERTIFICATE: './usr/local/share/certs/example.ca.pem'
       KONG_LOG_LEVEL: 'info'
-      KONG_PLUGINS: 'bundled,bff-token,phantom-token'
+      KONG_PLUGINS: 'bundled,oauth-proxy,phantom-token'
 
   #
   # A SQL database used by the Curity Identity Server

--- a/financial/reverse-proxy/kong.yml
+++ b/financial/reverse-proxy/kong.yml
@@ -26,7 +26,7 @@ services:
   plugins:
 
   # 1. The BFF plugin decrypts the secure cookie and forwards the opaque access token to the API endpoint
-  - name: bff-token
+  - name: oauth-proxy
     config:
       encryption_key: NF65meV>Ls#8GP>;!Cnov)rIPRoK^.NP
       cookie_name_prefix: example

--- a/standard/build.sh
+++ b/standard/build.sh
@@ -47,12 +47,19 @@ fi
 # Get the 'OAuth Proxy', which is a simple reverse proxy plugin
 #
 cd ..
-rm -rf kong-bff-plugin
-git clone https://github.com/curityio/kong-bff-plugin
+rm -rf oauth-proxy-plugin
+git clone https://github.com/curityio/kong-bff-plugin oauth-proxy-plugin
 if [ $? -ne 0 ]; then
-  echo "Problem encountered downloading the BFF plugin"
+  echo "Problem encountered downloading the OAuth proxy plugin"
   exit 1
 fi
+
+#
+# Temporary code OAuth proxy plugin changes are merged
+#
+cd oauth-proxy-plugin
+git checkout feature/nginx-lua-oauth-proxy-plugin
+cd ..
 
 #
 # Also download the phantom token plugin for the reverse proxy

--- a/standard/build.sh
+++ b/standard/build.sh
@@ -55,13 +55,6 @@ if [ $? -ne 0 ]; then
 fi
 
 #
-# Temporary code OAuth proxy plugin changes are merged
-#
-cd oauth-proxy-plugin
-git checkout feature/nginx-lua-oauth-proxy-plugin
-cd ..
-
-#
 # Also download the phantom token plugin for the reverse proxy
 #
 rm -rf kong-phantom-token-plugin

--- a/standard/docker-compose.yml
+++ b/standard/docker-compose.yml
@@ -60,14 +60,14 @@ services:
       - 3000:3000
     volumes:
       - ./reverse-proxy/kong.yml:/usr/local/kong/declarative/kong.yml
-      - ./kong-bff-plugin/plugin:/usr/local/share/lua/5.1/kong/plugins/bff-token
+      - ./oauth-proxy-plugin/plugin:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy
       - ./kong-phantom-token-plugin/plugin:/usr/local/share/lua/5.1/kong/plugins/phantom-token
     environment:
       KONG_DATABASE: 'off'
       KONG_DECLARATIVE_CONFIG: '/usr/local/kong/declarative/kong.yml'
       KONG_PROXY_LISTEN: '0.0.0.0:3000'
       KONG_LOG_LEVEL: 'info'
-      KONG_PLUGINS: 'bundled,bff-token,phantom-token'
+      KONG_PLUGINS: 'bundled,oauth-proxy,phantom-token'
 
   #
   # A SQL database used by the Curity Identity Server

--- a/standard/reverse-proxy/kong.yml
+++ b/standard/reverse-proxy/kong.yml
@@ -25,8 +25,8 @@ services:
 
   plugins:
 
-  # 1. The BFF plugin decrypts the secure cookie and forwards the opaque access token to the API endpoint
-  - name: bff-token
+  # 1. The OAuth proxy plugin decrypts the secure cookie and forwards the opaque access token to the API endpoint
+  - name: oauth-proxy
     config:
       encryption_key: NF65meV>Ls#8GP>;!Cnov)rIPRoK^.NP
       cookie_name_prefix: example


### PR DESCRIPTION
Some naming and path changes - I have tested both token handlers against the SPA so just cast your eye over this.
I will merge this and replace this code from the build.sh scripts once the main OAuth Proxy Plugin is merged.

```text
#
# Temporary code OAuth proxy plugin changes are merged
#
cd oauth-proxy-plugin
git checkout feature/nginx-lua-oauth-proxy-plugin
cd ..
```