### PR TITLE
Added luarocks deployment

### DIFF
--- a/financial/build.sh
+++ b/financial/build.sh
@@ -42,9 +42,9 @@ cd ..
 # Build the reverse proxy's custom dockerfile
 #
 cd reverse-proxy
-docker build -f Dockerfile -t custom_kong:2.6.0-alpine .
+docker build --no-cache -f Dockerfile -t custom_kong:2.6.0-alpine .
 if [ $? -ne 0 ]; then
-  echo "Problem encountered downloading the Kong OAuth Proxy Docker file"
+  echo "Problem encountered building the Reverse Proxy Docker file"
   exit 1
 fi
 cd ..

--- a/financial/build.sh
+++ b/financial/build.sh
@@ -36,17 +36,18 @@ if [ $? -ne 0 ]; then
   echo "Problem encountered building the OAuth Agent Docker file"
   exit 1
 fi
+cd ..
 
 #
-# Get the OAuth Proxy, which runs within an NGINX based reverse proxy
+# Build the reverse proxy's custom dockerfile
 #
-cd ..
-rm -rf oauth-proxy-plugin
-git clone https://github.com/curityio/nginx-lua-oauth-proxy-plugin oauth-proxy-plugin
+cd reverse-proxy
+docker build -f Dockerfile -t custom_kong:2.6.0-alpine .
 if [ $? -ne 0 ]; then
-  echo "Problem encountered downloading the OAuth proxy plugin"
+  echo "Problem encountered downloading the Kong OAuth Proxy Docker file"
   exit 1
 fi
+cd ..
 
 #
 # Also download the phantom token plugin for the reverse proxy

--- a/financial/docker-compose.yml
+++ b/financial/docker-compose.yml
@@ -77,16 +77,13 @@ services:
   # The reverse proxy routes to the OAuth Agent and the business API inside the cluster
   #
   reverse-proxy:
-    image: kong:2.6.0-alpine
+    image: custom_kong:2.6.0-alpine
     hostname: reverseproxy
     ports:
       - 3000:3000
     volumes:
       - ./reverse-proxy/kong.yml:/usr/local/kong/declarative/kong.yml
       - ./kong-phantom-token-plugin/plugin:/usr/local/share/lua/5.1/kong/plugins/phantom-token
-      - ./oauth-proxy-plugin/plugin/plugin.lua:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy/access.lua
-      - ./oauth-proxy-plugin/plugin/handler.lua:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy/handler.lua
-      - ./oauth-proxy-plugin/plugin/schema.lua:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy/schema.lua
       - ./certs/example.ca.pem:/usr/local/share/certs/example.ca.pem
       - ./certs/example.server.key:/usr/local/share/certs/example.server.key
       - ./certs/example.server.pem:/usr/local/share/certs/example.server.pem

--- a/financial/docker-compose.yml
+++ b/financial/docker-compose.yml
@@ -83,7 +83,6 @@ services:
       - 3000:3000
     volumes:
       - ./reverse-proxy/kong.yml:/usr/local/kong/declarative/kong.yml
-      - ./kong-phantom-token-plugin/plugin:/usr/local/share/lua/5.1/kong/plugins/phantom-token
       - ./certs/example.ca.pem:/usr/local/share/certs/example.ca.pem
       - ./certs/example.server.key:/usr/local/share/certs/example.server.key
       - ./certs/example.server.pem:/usr/local/share/certs/example.server.pem

--- a/financial/reverse-proxy/Dockerfile
+++ b/financial/reverse-proxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM kong:2.6.0-alpine
 
 USER root
-RUN luarocks install kong-oauth-proxy
+RUN git config --global url."https://".insteadOf git:// && luarocks install kong-oauth-proxy
 USER kong

--- a/financial/reverse-proxy/Dockerfile
+++ b/financial/reverse-proxy/Dockerfile
@@ -3,7 +3,7 @@ FROM kong:2.6.0-alpine
 # Fetch from luarocks, and set git options if required
 USER root
 RUN git config --global url."https://".insteadOf git:// && \
-    git config --global advice.detachedHead false &&
+    git config --global advice.detachedHead false && \
     luarocks install kong-oauth-proxy && \
     luarocks install kong-phantom-token
 

--- a/financial/reverse-proxy/Dockerfile
+++ b/financial/reverse-proxy/Dockerfile
@@ -1,0 +1,5 @@
+FROM kong:2.6.0-alpine
+
+USER root
+RUN luarocks install kong-oauth-proxy
+USER kong

--- a/financial/reverse-proxy/Dockerfile
+++ b/financial/reverse-proxy/Dockerfile
@@ -1,5 +1,7 @@
 FROM kong:2.6.0-alpine
 
 USER root
-RUN git config --global url."https://".insteadOf git:// && luarocks install kong-oauth-proxy
+RUN git config --global url."https://".insteadOf git:// && \
+    luarocks install kong-oauth-proxy && \
+    luarocks install kong-phantom-token
 USER kong

--- a/financial/reverse-proxy/Dockerfile
+++ b/financial/reverse-proxy/Dockerfile
@@ -1,7 +1,10 @@
 FROM kong:2.6.0-alpine
 
+# Fetch from luarocks, and set git options if required
 USER root
 RUN git config --global url."https://".insteadOf git:// && \
+    git config --global advice.detachedHead false &&
     luarocks install kong-oauth-proxy && \
     luarocks install kong-phantom-token
+
 USER kong

--- a/standard/build.sh
+++ b/standard/build.sh
@@ -48,9 +48,9 @@ cd ..
 # Build the reverse proxy's custom dockerfile
 #
 cd reverse-proxy
-docker build -f Dockerfile -t custom_kong:2.6.0-alpine .
+docker build --no-cache -f Dockerfile -t custom_kong:2.6.0-alpine .
 if [ $? -ne 0 ]; then
-  echo "Problem encountered downloading the Kong OAuth Proxy Docker file"
+  echo "Problem encountered building the Reverse Proxy Docker file"
   exit 1
 fi
 cd ..

--- a/standard/build.sh
+++ b/standard/build.sh
@@ -42,17 +42,18 @@ if [ $? -ne 0 ]; then
   echo "Problem encountered building the OAuth Agent Docker file"
   exit 1
 fi
+cd ..
 
 #
-# Get the OAuth Proxy, which runs within an NGINX based reverse proxy
+# Build the reverse proxy's custom dockerfile
 #
-cd ..
-rm -rf oauth-proxy-plugin
-git clone https://github.com/curityio/nginx-lua-oauth-proxy-plugin oauth-proxy-plugin
+cd reverse-proxy
+docker build -f Dockerfile -t custom_kong:2.6.0-alpine .
 if [ $? -ne 0 ]; then
-  echo "Problem encountered downloading the OAuth proxy plugin"
+  echo "Problem encountered downloading the Kong OAuth Proxy Docker file"
   exit 1
 fi
+cd ..
 
 #
 # Also download the phantom token plugin for the reverse proxy

--- a/standard/docker-compose.yml
+++ b/standard/docker-compose.yml
@@ -59,7 +59,6 @@ services:
       - 3000:3000
     volumes:
       - ./reverse-proxy/kong.yml:/usr/local/kong/declarative/kong.yml
-      - ./kong-phantom-token-plugin/plugin:/usr/local/share/lua/5.1/kong/plugins/phantom-token
     environment:
       KONG_DATABASE: 'off'
       KONG_DECLARATIVE_CONFIG: '/usr/local/kong/declarative/kong.yml'

--- a/standard/docker-compose.yml
+++ b/standard/docker-compose.yml
@@ -53,16 +53,13 @@ services:
   # The Kong reverse proxy exposes API endpoints to the browser at http://api.example.com:3000
   #
   reverse-proxy:
-    image: kong:2.6.0-alpine
+    image: custom_kong:2.6.0-alpine
     hostname: reverseproxy
     ports:
       - 3000:3000
     volumes:
       - ./reverse-proxy/kong.yml:/usr/local/kong/declarative/kong.yml
       - ./kong-phantom-token-plugin/plugin:/usr/local/share/lua/5.1/kong/plugins/phantom-token
-      - ./oauth-proxy-plugin/plugin/plugin.lua:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy/access.lua
-      - ./oauth-proxy-plugin/plugin/handler.lua:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy/handler.lua
-      - ./oauth-proxy-plugin/plugin/schema.lua:/usr/local/share/lua/5.1/kong/plugins/oauth-proxy/schema.lua
     environment:
       KONG_DATABASE: 'off'
       KONG_DECLARATIVE_CONFIG: '/usr/local/kong/declarative/kong.yml'

--- a/standard/reverse-proxy/Dockerfile
+++ b/standard/reverse-proxy/Dockerfile
@@ -2,8 +2,8 @@ FROM kong:2.6.0-alpine
 
 # Fetch from luarocks, and set git options if required
 USER root
-RUN git config --global url."https://".insteadOf git:// && 
-    git config --global advice.detachedHead false &&
+RUN git config --global url."https://".insteadOf git:// && \
+    git config --global advice.detachedHead false && \
     luarocks install kong-oauth-proxy && \
     luarocks install kong-phantom-token
 

--- a/standard/reverse-proxy/Dockerfile
+++ b/standard/reverse-proxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM kong:2.6.0-alpine
 
 USER root
-RUN luarocks install kong-oauth-proxy
+RUN git config --global url."https://".insteadOf git:// && luarocks install kong-oauth-proxy
 USER kong

--- a/standard/reverse-proxy/Dockerfile
+++ b/standard/reverse-proxy/Dockerfile
@@ -1,7 +1,10 @@
 FROM kong:2.6.0-alpine
 
+# Fetch from luarocks, and set git options if required
 USER root
-RUN git config --global url."https://".insteadOf git:// && \
+RUN git config --global url."https://".insteadOf git:// && 
+    git config --global advice.detachedHead false &&
     luarocks install kong-oauth-proxy && \
     luarocks install kong-phantom-token
+
 USER kong

--- a/standard/reverse-proxy/Dockerfile
+++ b/standard/reverse-proxy/Dockerfile
@@ -1,0 +1,5 @@
+FROM kong:2.6.0-alpine
+
+USER root
+RUN luarocks install kong-oauth-proxy
+USER kong

--- a/standard/reverse-proxy/Dockerfile
+++ b/standard/reverse-proxy/Dockerfile
@@ -1,5 +1,7 @@
 FROM kong:2.6.0-alpine
 
 USER root
-RUN git config --global url."https://".insteadOf git:// && luarocks install kong-oauth-proxy
+RUN git config --global url."https://".insteadOf git:// && \
+    luarocks install kong-oauth-proxy && \
+    luarocks install kong-phantom-token
 USER kong


### PR DESCRIPTION
Previous process:
- Build step: git clone plugin repos
- Deploy step: use Kong default Docker image + docker compose file copying to hard coded paths

New process:
- Build step: custom Docker image for reverse proxy, which does a luarocks install
- Deploy step: deploy custom Docker image

Both processes still work, but the second is better from the viewpoints of versioning and being customer friendly