### PR TITLE
Fix removal of example.ca.srl -> example.srl

### DIFF
--- a/certs/create-certs.sh
+++ b/certs/create-certs.sh
@@ -148,5 +148,5 @@ openssl pkcs12 \
 #
 rm example.server.csr
 rm example.client.csr
-rm example.srl
+rm example*.srl
 echo '*** Successfully created all certificate files'

--- a/certs/create-certs.sh
+++ b/certs/create-certs.sh
@@ -148,5 +148,5 @@ openssl pkcs12 \
 #
 rm example.server.csr
 rm example.client.csr
-rm example.ca.srl
+rm example.srl
 echo '*** Successfully created all certificate files'


### PR DESCRIPTION
`rm  example.ca.srl` command failed because the file didn't exists, causing the script to fail. 
The correct file to remove is `example.ca.srl`.