### PR TITLE
Fix certificate new line handling on Windows with git bash

### DIFF
--- a/deploy-idsvr-certs.sh
+++ b/deploy-idsvr-certs.sh
@@ -16,6 +16,24 @@ IDENTITY_SERVER_TLS_NAME='Identity_Server_TLS'
 PRIVATE_KEY_PASSWORD='Password1'
 
 #
+# Get platform specific differences
+#
+case "$(uname -s)" in
+
+  Linux)
+    LINE_SEPARATOR='\n'
+	;;
+  
+  Darwin)
+    LINE_SEPARATOR='\n'
+ 	;;
+
+  MINGW64*)
+    LINE_SEPARATOR='\r\n'
+	;;
+esac
+
+#
 # Wait for the admin endpoint to become available
 #
 echo "Waiting for the Curity Identity Server ..."
@@ -26,7 +44,7 @@ done
 #
 # Add the SSL key and use the private key password to protect it in transit
 #
-export IDENTITY_SERVER_TLS_DATA=$(openssl base64 -in ./certs/example.server.p12 | tr -d '\n')
+export IDENTITY_SERVER_TLS_DATA=$(openssl base64 -in ./certs/example.server.p12 | tr -d "$LINE_SEPARATOR")
 echo "Updating SSL certificate ..."
 HTTP_STATUS=$(curl -k -s \
 -X POST "$RESTCONF_BASE_URL/base:facilities/crypto/add-ssl-server-keystore" \

--- a/deploy.sh
+++ b/deploy.sh
@@ -37,6 +37,24 @@ if [ $? -ne 0 ]; then
 fi
 
 #
+# Get platform specific differences
+#
+case "$(uname -s)" in
+
+  Linux)
+    LINE_SEPARATOR='\n'
+	;;
+  
+  Darwin)
+    LINE_SEPARATOR='\n'
+ 	;;
+
+  MINGW64*)
+    LINE_SEPARATOR='\r\n'
+	;;
+esac
+
+#
 # Get the scenario to deploy and set some variables
 #
 if [ "$1" == 'financial' ]; then
@@ -201,7 +219,7 @@ if [ "$SCENARIO" == 'financial' ]; then
       exit 1
     fi
   fi
-  export FINANCIAL_GRADE_CLIENT_CA=$(openssl base64 -in './certs/example.ca.pem' | tr -d '\n')
+  export FINANCIAL_GRADE_CLIENT_CA=$(openssl base64 -in './certs/example.ca.pem' | tr -d "$LINE_SEPARATOR")
 fi
 
 #


### PR DESCRIPTION
Previously we were using  `tr -d \n` logic to remove newlines from multi line certificate text.
On Windows this needs to be `tr -d \r\n`, since there is also a line feed character.