### PR TITLE
Update NGINX and Kong versions to latest

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ echo "Building resources for the $OAUTH_AGENT OAuth agent and $OAUTH_PROXY API g
 cd components/api-gateway
 if [ "$OAUTH_PROXY" == 'NGINX' ]; then
 
-  docker build --no-cache -f nginx/Dockerfile -t custom_nginx:1.21.6-alpine .
+  docker build --no-cache -f nginx/Dockerfile -t custom_nginx:1.23.2-alpine .
   if [ $? -ne 0 ]; then
     echo "Problem encountered building the NGINX docker image"
     exit 1
@@ -55,9 +55,9 @@ elif [ "$OAUTH_PROXY" == 'OPENRESTY' ]; then
     exit 1
   fi
 
-elif [ "$OAUTH_AGENT" == 'KONG' ]; then
+elif [ "$OAUTH_PROXY" == 'KONG' ]; then
   
-  docker build --no-cache -f kong/Dockerfile -t custom_kong:3.0.0 .
+  docker build --no-cache -f kong/Dockerfile -t custom_kong:3.1.1 .
   if [ $? -ne 0 ]; then
     echo "Problem encountered building the Kong docker image"
     exit 1

--- a/components/api-gateway/kong/Dockerfile
+++ b/components/api-gateway/kong/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong:3.0.0
+FROM kong:3.1.1-ubuntu
 
 # Fetch from luarocks, and set git options if required
 USER root

--- a/components/api-gateway/nginx/Dockerfile
+++ b/components/api-gateway/nginx/Dockerfile
@@ -1,5 +1,5 @@
-FROM nginx:1.21.6-alpine
+FROM nginx:1.23.2-alpine
 
 # Download the built modules from Curity GitHub repo
-RUN curl -s -L 'https://github.com/curityio/nginx_phantom_token_module/releases/download/1.3.0/alpine.ngx_curity_http_phantom_token_module_1.21.6.so' > /usr/lib/nginx/modules/ngx_curity_http_phantom_token_module.so
-RUN curl -s -L 'https://github.com/curityio/nginx_oauth_proxy_module/releases/download/1.2.0/alpine.ngx_curity_http_oauth_proxy_module_1.21.6.so'     > /usr/lib/nginx/modules/ngx_curity_http_oauth_proxy_module.so
+RUN curl -s -L 'https://github.com/curityio/nginx_phantom_token_module/releases/download/1.4.0/alpine.ngx_curity_http_phantom_token_module_1.23.2.so' > /usr/lib/nginx/modules/ngx_curity_http_phantom_token_module.so
+RUN curl -s -L 'https://github.com/curityio/nginx_oauth_proxy_module/releases/download/1.3.0/alpine.ngx_curity_http_oauth_proxy_module_1.23.2.so'     > /usr/lib/nginx/modules/ngx_curity_http_oauth_proxy_module.so

--- a/docker-compose-financial.yml
+++ b/docker-compose-financial.yml
@@ -76,7 +76,7 @@ services:
   # The API gateway routes to the OAuth Agent and the business API inside the cluster
   #
   kong-api-gateway:
-    image: custom_kong:3.0.0
+    image: custom_kong:3.1.1
     hostname: apigateway
     ports:
       - 443:3000
@@ -102,7 +102,7 @@ services:
   # Use NGINX and C modules
   #
   nginx-api-gateway:
-    image: custom_nginx:1.21.6-alpine
+    image: custom_nginx:1.23.2-alpine
     hostname: apigateway
     ports:
       - 443:3000

--- a/docker-compose-financial.yml
+++ b/docker-compose-financial.yml
@@ -150,7 +150,7 @@ services:
   # A standalone instance of the Curity Identity Server
   #
   curity-idsvr:
-    image: curity.azurecr.io/curity/idsvr:7.6.0
+    image: curity.azurecr.io/curity/idsvr:latest
     hostname: login-${INTERNAL_DOMAIN}
     ports:
       - 6749:6749

--- a/docker-compose-standard.yml
+++ b/docker-compose-standard.yml
@@ -118,7 +118,7 @@ services:
   # A standalone instance of the Curity Identity Server
   #
   curity-idsvr:
-    image: curity.azurecr.io/curity/idsvr:7.6.0
+    image: curity.azurecr.io/curity/idsvr:latest
     hostname: login-${INTERNAL_DOMAIN}
     ports:
       - 6749:6749

--- a/docker-compose-standard.yml
+++ b/docker-compose-standard.yml
@@ -56,7 +56,7 @@ services:
   # Use Kong and LUA plugins
   #
   kong-api-gateway:
-    image: custom_kong:3.0.0
+    image: custom_kong:3.1.1
     hostname: apigateway
     ports:
       - 80:3000
@@ -76,7 +76,7 @@ services:
   # Use NGINX and C modules
   #
   nginx-api-gateway:
-    image: custom_nginx:1.21.6-alpine
+    image: custom_nginx:1.23.2-alpine
     hostname: apigateway
     ports:
       - 80:3000


### PR DESCRIPTION
NGINX updated to 1.23.2
Kong updated to 3.1.1

The latest Kong default docker image for Alpine does not include git.
Rather than install git with a package manager, I updated to the Kong ubuntu image.
I could have alternatively used the package manager to install git, but this feels simpler I think.