### PR TITLE
Demonstrate pure SPA development

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-###########################################
-# A script to build Token Handler resources
-###########################################
+###############################################################################
+# A script to build resources of the end to end solution into Docker containers
+###############################################################################
 
 #
 # Ensure that we are in the folder containing this script

--- a/deploy.sh
+++ b/deploy.sh
@@ -194,7 +194,7 @@ echo -n $ENCRYPTION_KEY > encryption.key
 #
 # Disable CORS when web content and token handler are hosted in the same domain
 #
-if [ "$WEB_DOMAIN" == "$API_DOMAINGA" ]; then
+if [ "$WEB_DOMAIN" == "$API_DOMAIN" ]; then
   CORS_ENABLED='false'
   CORS_ENABLED_NGINX='off'
 else

--- a/deploy.sh
+++ b/deploy.sh
@@ -186,13 +186,21 @@ else
 fi
 
 #
-# In development mode the web host runs locally on port 80 or 443, so use a different gateway port
+# The web host and static content are deployed to Docker containers by default
+#
+WEBHOST_PROFILE='WITH_WEBHOST'
+
+#
+# In development mode, the web host and static content run locally instead
+# In this case we continue to use port 80 or 443 for the SPA and the gateway uses a different port
 #
 if [ "$DEVELOPMENT" == 'true' ]; then
   WEBHOST_PROFILE='WITHOUT_WEBHOST'
-  GATEWAY_PORT=3000
-else
-  WEBHOST_PROFILE='WITH_WEBHOST'
+  if [ "$OAUTH_AGENT" == 'FINANCIAL' ]; then
+    GATEWAY_PORT=444
+  else
+    GATEWAY_PORT=81
+  fi
 fi
 
 #
@@ -204,7 +212,7 @@ echo -n $ENCRYPTION_KEY > encryption.key
 #
 # Disable CORS when web content and token handler are hosted in the same domain
 #
-if [ "$WEB_DOMAIN" == "$API_DOMAIN" ]; then
+if [ "$WEB_DOMAIN" == "$API_DOMAINGA" ]; then
   CORS_ENABLED='false'
   CORS_ENABLED_NGINX='off'
 else

--- a/deploy.sh
+++ b/deploy.sh
@@ -211,14 +211,14 @@ if [ "$DEVELOPMENT" == 'true' ]; then
   # In development mode, the web host and static content run locally instead
   WEBHOST_PROFILE='WITHOUT_WEBHOST'
 
-  # In this case we continue to use port 80 or 443 for the SPA and the gateway uses a different port
+  # In this case we continue to use port 80 or 443 for the SPA, and the gateway uses a different port
   if [ "$OAUTH_AGENT" == 'FINANCIAL' ]; then
     GATEWAY_PORT=444
   else
     GATEWAY_PORT=81
   fi
 
-  # Since the web host uses a different port to the token handler, CORS is required
+  # Since the web host uses a different port to the gateway, CORS is required
   CORS_ENABLED='true'
   CORS_ENABLED_NGINX='on'
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -186,24 +186,6 @@ else
 fi
 
 #
-# The web host and static content are deployed to Docker containers by default
-#
-WEBHOST_PROFILE='WITH_WEBHOST'
-
-#
-# In development mode, the web host and static content run locally instead
-# In this case we continue to use port 80 or 443 for the SPA and the gateway uses a different port
-#
-if [ "$DEVELOPMENT" == 'true' ]; then
-  WEBHOST_PROFILE='WITHOUT_WEBHOST'
-  if [ "$OAUTH_AGENT" == 'FINANCIAL' ]; then
-    GATEWAY_PORT=444
-  else
-    GATEWAY_PORT=81
-  fi
-fi
-
-#
 # Supply the 32 byte encryption key for AES256 as an environment variable
 #
 ENCRYPTION_KEY=$(openssl rand 32 | xxd -p -c 64)
@@ -216,6 +198,27 @@ if [ "$WEB_DOMAIN" == "$API_DOMAINGA" ]; then
   CORS_ENABLED='false'
   CORS_ENABLED_NGINX='off'
 else
+  CORS_ENABLED='true'
+  CORS_ENABLED_NGINX='on'
+fi
+
+#
+# The web host and static content are deployed to Docker containers by default
+#
+WEBHOST_PROFILE='WITH_WEBHOST'
+if [ "$DEVELOPMENT" == 'true' ]; then
+  
+  # In development mode, the web host and static content run locally instead
+  WEBHOST_PROFILE='WITHOUT_WEBHOST'
+
+  # In this case we continue to use port 80 or 443 for the SPA and the gateway uses a different port
+  if [ "$OAUTH_AGENT" == 'FINANCIAL' ]; then
+    GATEWAY_PORT=444
+  else
+    GATEWAY_PORT=81
+  fi
+
+  # Since the web host uses a different port to the token handler, CORS is required
   CORS_ENABLED='true'
   CORS_ENABLED_NGINX='on'
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -186,10 +186,11 @@ else
 fi
 
 #
-# In development mode the web host is not deployed
+# In development mode the web host runs locally on port 80 or 443, so use a different gateway port
 #
 if [ "$DEVELOPMENT" == 'true' ]; then
   WEBHOST_PROFILE='WITHOUT_WEBHOST'
+  GATEWAY_PORT=3000
 else
   WEBHOST_PROFILE='WITH_WEBHOST'
 fi

--- a/docker-compose-financial.yml
+++ b/docker-compose-financial.yml
@@ -13,11 +13,13 @@ services:
       - ./certs/example.server.p12:/usr/webhost/certs/example.server.p12
     environment:
       NODE_ENV: 'production'
+    profiles:
+      - WITH_WEBHOST
 
   #
   # Deploy the example business API, which is a simple API that just validates JWTs
   # It runs on port 3002 inside the cluster at https://api.internal-example.com:3002
-  # The SPA accesses it via the API gateway at https://api.example.com:3000/api
+  # The SPA accesses it via the API gateway at https://api.example.com/api
   # The API calls the Authorization Server's JWKS endpoint inside the cluster
   #
   business-api:
@@ -33,7 +35,7 @@ services:
   #
   # The OAuth Agent provided by Curity is hosted here, to perform the OpenID Connect work
   # It runs on port 3001 inside the cluster at https://oauthagent.internal-example.com:3001
-  # The SPA accesses it via the API gateway at https://api.example.com:3000/oauth-agent
+  # The SPA accesses it via the API gateway at https://api.example.com/oauth-agent
   # The OAuth Agent calls the Authorization Server's token endpoint inside the cluster
   #
   oauth-agent:
@@ -72,14 +74,14 @@ services:
              java -jar /usr/api/oauth-agent-0.0.1-SNAPSHOT.jar"
 
   #
-  # The Kong API gateway exposes API endpoints to the browser at https://api.example.com:3000
+  # The Kong API gateway exposes API endpoints to the browser at https://api.example.com
   # The API gateway routes to the OAuth Agent and the business API inside the cluster
   #
   kong-api-gateway:
     image: custom_kong:3.3.0
     hostname: apigateway
     ports:
-      - 443:3000
+      - ${GATEWAY_PORT}:3000
     volumes:
       - ./components/api-gateway/kong/kong.yml:/usr/local/kong/declarative/kong.yml
       - ./certs/example.ca.pem:/usr/local/share/certs/example.ca.pem

--- a/docker-compose-standard.yml
+++ b/docker-compose-standard.yml
@@ -12,11 +12,13 @@ services:
       - ./components/spa/config.json:/usr/webhost/content/config.json
     environment:
       NODE_ENV: 'production'
+    profiles:
+      - WITH_WEBHOST
 
   #
   # Deploy the example business API, which is a simple API that just validates JWTs
   # It runs on port 3002 inside the cluster at http://api.internal-example.com:3002
-  # The SPA accesses it via the API gateway at http://api.example.com:3000/api
+  # The SPA accesses it via the API gateway at http://api.example.com/api
   #
   business-api:
     image: business-api:1.0.0
@@ -27,7 +29,7 @@ services:
   #
   # An OAuth Agent provided by Curity is hosted here, to perform the OpenID Connect work
   # It runs on port 3001 inside the cluster at http://oauthagent.internal-example.com:3001
-  # The SPA accesses it via the API gateway at http://api.example.com:3000/oauth-agent
+  # The SPA accesses it via the API gateway at http://api.example.com/oauth-agent
   #
   oauth-agent:
     image: oauthagent:1.0.0
@@ -59,7 +61,7 @@ services:
     image: custom_kong:3.3.0
     hostname: apigateway
     ports:
-      - 80:3000
+      - ${GATEWAY_PORT}:3000
     volumes:
       - ./components/api-gateway/kong/kong.yml:/usr/local/kong/declarative/kong.yml
     environment:


### PR DESCRIPTION
I added an option so that the SPA code runs locally in watch mode, rather than being deployed to Docker compose:

```bash
export DEVELOPMENT=true
./build.sh
```

You then run another terminal window to deploy components, and the Express web host also runs locally:

```bash
export DEVELOPMENT=true
./deploy.sh
```