### PR TITLE
Updated example API gateways to use latest versions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ if [ "$OAUTH_PROXY" == 'NGINX' ]; then
   
 elif [ "$OAUTH_PROXY" == 'OPENRESTY' ]; then
 
-  docker build --no-cache -f openresty/Dockerfile -t custom_openresty/openresty:1.21.4.1-bionic .
+  docker build --no-cache -f openresty/Dockerfile -t custom_openresty/openresty:1.21.4.1-jammy .
   if [ $? -ne 0 ]; then
     echo "Problem encountered building the OpenResty docker image"
     exit 1
@@ -57,7 +57,7 @@ elif [ "$OAUTH_PROXY" == 'OPENRESTY' ]; then
 
 elif [ "$OAUTH_PROXY" == 'KONG' ]; then
   
-  docker build --no-cache -f kong/Dockerfile -t custom_kong:3.3.0 .
+  docker build --no-cache -f kong/Dockerfile -t custom_kong:3.4.0 .
   if [ $? -ne 0 ]; then
     echo "Problem encountered building the Kong docker image"
     exit 1

--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ echo "Building resources for the $OAUTH_AGENT OAuth agent and $OAUTH_PROXY API g
 cd components/api-gateway
 if [ "$OAUTH_PROXY" == 'NGINX' ]; then
 
-  docker build --no-cache -f nginx/Dockerfile -t custom_nginx:1.23.2-alpine .
+  docker build --no-cache -f nginx/Dockerfile -t custom_nginx:1.25.1-alpine .
   if [ $? -ne 0 ]; then
     echo "Problem encountered building the NGINX docker image"
     exit 1

--- a/components/api-gateway/kong/Dockerfile
+++ b/components/api-gateway/kong/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong:3.3.0-ubuntu
+FROM kong:3.4.0-ubuntu
 
 # Fetch from luarocks, and set git options if required
 USER root

--- a/components/api-gateway/nginx/Dockerfile
+++ b/components/api-gateway/nginx/Dockerfile
@@ -1,5 +1,5 @@
-FROM nginx:1.23.2-alpine
+FROM nginx:1.25.1-alpine
 
 # Download the built modules from Curity GitHub repo
-RUN curl -s -L 'https://github.com/curityio/nginx_phantom_token_module/releases/download/1.4.0/alpine.ngx_curity_http_phantom_token_module_1.23.2.so' > /usr/lib/nginx/modules/ngx_curity_http_phantom_token_module.so
-RUN curl -s -L 'https://github.com/curityio/nginx_oauth_proxy_module/releases/download/1.3.0/alpine.ngx_curity_http_oauth_proxy_module_1.23.2.so'     > /usr/lib/nginx/modules/ngx_curity_http_oauth_proxy_module.so
+RUN curl -s -L 'https://github.com/curityio/nginx_phantom_token_module/releases/download/1.5.0/alpine.ngx_curity_http_phantom_token_module_1.25.1.so' > /usr/lib/nginx/modules/ngx_curity_http_phantom_token_module.so
+RUN curl -s -L 'https://github.com/curityio/nginx_oauth_proxy_module/releases/download/1.4.0/alpine.ngx_curity_http_oauth_proxy_module_1.25.1.so'     > /usr/lib/nginx/modules/ngx_curity_http_oauth_proxy_module.so

--- a/components/api-gateway/openresty/Dockerfile
+++ b/components/api-gateway/openresty/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:1.21.4.1-bionic
+FROM openresty/openresty:1.21.4.1-jammy
 
 # Fetch from luarocks, and set git options if required
 RUN apt-get update && apt-get install git -y

--- a/docker-compose-financial.yml
+++ b/docker-compose-financial.yml
@@ -102,7 +102,7 @@ services:
   # Use NGINX and C modules
   #
   nginx-api-gateway:
-    image: custom_nginx:1.23.2-alpine
+    image: custom_nginx:1.25.1-alpine
     hostname: apigateway
     ports:
       - 443:3000

--- a/docker-compose-financial.yml
+++ b/docker-compose-financial.yml
@@ -76,7 +76,7 @@ services:
   # The API gateway routes to the OAuth Agent and the business API inside the cluster
   #
   kong-api-gateway:
-    image: custom_kong:3.3.0
+    image: custom_kong:3.4.0
     hostname: apigateway
     ports:
       - 443:3000
@@ -119,7 +119,7 @@ services:
   # Use OpenResty and LUA plugins
   #
   openresty-api-gateway:
-    image: custom_openresty/openresty:1.21.4.1-bionic
+    image: custom_openresty/openresty:1.21.4.1-jammy
     hostname: apigateway
     ports:
       - 443:3000

--- a/docker-compose-standard.yml
+++ b/docker-compose-standard.yml
@@ -76,7 +76,7 @@ services:
   # Use NGINX and C modules
   #
   nginx-api-gateway:
-    image: custom_nginx:1.23.2-alpine
+    image: custom_nginx:1.25.1-alpine
     hostname: apigateway
     ports:
       - 80:3000

--- a/docker-compose-standard.yml
+++ b/docker-compose-standard.yml
@@ -56,7 +56,7 @@ services:
   # Use Kong and LUA plugins
   #
   kong-api-gateway:
-    image: custom_kong:3.3.0
+    image: custom_kong:3.4.0
     hostname: apigateway
     ports:
       - 80:3000
@@ -90,7 +90,7 @@ services:
   # Use OpenResty and LUA plugins
   #
   openresty-api-gateway:
-    image: custom_openresty/openresty:1.21.4.1-bionic
+    image: custom_openresty/openresty:1.21.4.1-jammy
     hostname: apigateway
     ports:
       - 80:3000


### PR DESCRIPTION
Integration updates to versions as part of NGINX module testing:
- NGINX from 1.23.2 to 1.23.5 and use latest NGINX modules
- Kong from 3.3.0 to 3.4.0
- OpenResty from bionic (v18.04) to jammy (v22.04)